### PR TITLE
Feat/gke ip exhaustion demo

### DIFF
--- a/gcp/terraform/Makefile
+++ b/gcp/terraform/Makefile
@@ -7,7 +7,7 @@ TF_PLAN_FILE=$(ROOT_DIR)/tfplan
 ####
 
 .PHONY: create-vpc
-create-vpc:
+create-vpc: tf-init
 	$(MAKE) -C $(ROOT_DIR)/foundation tf-apply
 
 

--- a/gcp/terraform/main.tf
+++ b/gcp/terraform/main.tf
@@ -26,17 +26,16 @@ module "gke" {
   horizontal_pod_autoscaling = true
   default_max_pods_per_node  = 16
   datapath_provider          = "ADVANCED_DATAPATH"
-  kubernetes_version         = "1.26.7"
   configure_ip_masq          = false
   remove_default_node_pool   = true
 
   node_pools = [
     {
-      name               = "test-nodepool"
+      name               = "original-nodepool"
       machine_type       = "e2-standard-2"
       node_locations     = "${var.region}-b"
       min_count          = 2
-      max_count          = 3
+      max_count          = 7
       local_ssd_count    = 0
       disk_size_gb       = 50
       disk_type          = "pd-standard"
@@ -61,7 +60,7 @@ module "gke" {
   node_pools_metadata = {
     all = {}
 
-    test-nodepool = {
+    original-nodepool = {
       node-pool-metadata-custom-value = "my-node-pool"
     }
   }
@@ -69,9 +68,9 @@ module "gke" {
   node_pools_taints = {
     all = []
 
-    test-nodepool = [
+    original-nodepool = [
       {
-        key    = "test-nodepool"
+        key    = "original-nodepool"
         value  = true
         effect = "PREFER_NO_SCHEDULE"
       },
@@ -81,8 +80,8 @@ module "gke" {
   node_pools_tags = {
     all = []
 
-    test-nodepool = [
-      "test-nodepool",
+    original-nodepool = [
+      "original-nodepool",
     ]
   }
 }

--- a/gcp/terraform/main.tf
+++ b/gcp/terraform/main.tf
@@ -24,7 +24,7 @@ module "gke" {
   ip_range_pods              = "pod-range"
   ip_range_services          = "svc-range"
   horizontal_pod_autoscaling = true
-  default_max_pods_per_node  = 64
+  default_max_pods_per_node  = 16
   datapath_provider          = "ADVANCED_DATAPATH"
   kubernetes_version         = "1.26.7"
   configure_ip_masq          = false


### PR DESCRIPTION
Reproduce Pod IP exhaustion - pod triggered scale up and there is enough space in terms of nodegroup max size, but node failed to provision:

<img width="1220" alt="Screenshot 2023-11-03 at 6 11 28 pm-pod-ip-exhaustion-failed-scale-up" src="https://github.com/olga-mir/k8s/assets/5200844/d7596dd1-6fc7-4ed6-ace8-61faab513c52">

Added new range to the subnet called `pod-range-2`. The ranges must satisfy `Subnetwork IP ranges must be unique and non-overlapping within a VPC network and peered VPC network` but they don't have to be from different blocks. These blocks were chosen to make it easier for the demo to show that pods IPs come from different sources.


```
% gcloud compute networks subnets describe cluster --region=australia-southeast1  | yq '.secondaryIpRanges'
- ipCidrRange: 10.0.0.0/26
  rangeName: pod-range
- ipCidrRange: 172.16.0.0/20
  rangeName: svc-range
- ipCidrRange: 192.168.0.0/22
  rangeName: pod-range-2
```  

Create new nodepool:

```
~% gcloud container node-pools create new-nodepool \
    --cluster=demo-ip \
    --node-locations=$az \
    --location-policy=BALANCED \
    --enable-autoscaling \
    --total-max-nodes=10 \
    --max-pods-per-node=32 \
    --pod-ipv4-range=pod-range-2 \
    --spot
```

the same pod is now scheduled on the new node. Also scaled deployment to demonstrate they can schedule on the old nodepool (after removing some of old pods from there).

```
~ % k get po -o wide
NAME                           READY   STATUS    RESTARTS   AGE     IP              NODE                                          NOMINATED NODE   READINESS GATES
alpine-curl-648f8f669c-2hqmg   1/1     Running   0          11s     10.0.0.45       gke-demo-ip-original-nodepool-22330990-8f44   <none>           <none>
alpine-curl-648f8f669c-2xtbq   1/1     Running   0          11s     10.0.0.15       gke-demo-ip-original-nodepool-22330990-zzzt   <none>           <none>
alpine-curl-648f8f669c-8mplc   1/1     Running   0          9m31s   192.168.0.130   gke-demo-ip-new-nodepool-ca0b68f2-6p7z        <none>           <none>
alpine-curl-648f8f669c-9zxzn   1/1     Running   0          9m31s   192.168.0.66    gke-demo-ip-new-nodepool-ca0b68f2-4jtg        <none>           <none>
alpine-curl-648f8f669c-wltzt   1/1     Running   0          17m     192.168.0.4     gke-demo-ip-new-nodepool-ca0b68f2-cj94        <none>           <none>
~ %
~ % k describe po alpine-curl-648f8f669c-wltzt | grep -A 15 "Events:"

Events:
  Type     Reason             Age                 From                Message
  ----     ------             ----                ----                -------
  Normal   TriggeredScaleUp   17m (x2 over 22m)   cluster-autoscaler  pod triggered scale-up: [{https://www.googleapis.com/compute/v1/projects/<proj_id>/zones/<az>/instanceGroups/gke-demo-ip-original-nodepool-22330990-grp 2->3 (max: 7)}]
  Warning  FailedScheduling   16m (x3 over 22m)   default-scheduler   0/2 nodes are available: 2 Too many pods. preemption: 0/2 nodes are available: 2 No preemption victims found for incoming pod..
  Warning  FailedScaleUp      16m (x2 over 22m)   cluster-autoscaler  Node scale up in zones <az> associated with this pod failed: IP space exhausted. Pod is at risk of not being scheduled.
  Normal   NotTriggerScaleUp  16m (x29 over 21m)  cluster-autoscaler  pod didn't trigger scale-up: 1 in backoff after failed scale-up
  Normal   Scheduled          14m                 default-scheduler   Successfully assigned test/alpine-curl-648f8f669c-wltzt to gke-demo-ip-new-nodepool-ca0b68f2-cj94
  Normal   Pulling            14m                 kubelet             Pulling image "alpine/curl"
  Normal   Pulled             14m                 kubelet             Successfully pulled image "alpine/curl" in 5.618979956s (5.618994877s including waiting)
  Normal   Created            14m                 kubelet             Created container alpine-curl
  Normal   Started            14m                 kubelet             Started container alpine-curl
```

Now we have nodes from old and new range: 

<img width="661" alt="Screenshot 2023-11-03 at 8 13 33 pm" src="https://github.com/olga-mir/k8s/assets/5200844/58fa4250-2781-4dbc-b22b-99580cb50d9e">
